### PR TITLE
Remove extra deps from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,6 @@ setup(
         "fsspec>=0.3.3",
         "s3fs",
         "jsonschema>=3",
-        "h5py",
-        "numexpr",
-        "scipy",
-        "ephem",
         "requests"
     ],
     tests_require=tests_require,


### PR DESCRIPTION
I think these may have been added to make Fractional Cover work, but this is
entirely the wrong place to keep them.

Closes: #24
----

#