### PR TITLE
Add acl to s3 sync command

### DIFF
--- a/datacube_alchemist/worker.py
+++ b/datacube_alchemist/worker.py
@@ -405,6 +405,7 @@ class Alchemist:
                         "s3",
                         "sync",
                         "--only-show-errors",
+                        "--acl bucket-owner-full-control",
                         str(dataset_assembler._dataset_location),
                         s3_location,
                     ]


### PR DESCRIPTION
I think it's ok to make this always on. There's no downside to the assertion...