### PR TITLE
Pin wofs and fc to known versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ fc-broken-dry:
 wofs-one:
 	docker-compose exec alchemist \
 		datacube-alchemist run-one --config-file ./examples/c3_config_wo.yaml \
-		--uuid 7b9553d4-3367-43fe-8e6f-b45999c5ada6 --dryrun
+		--uuid 7b9553d4-3367-43fe-8e6f-b45999c5ada6
 
 wofs-many:
 	docker-compose exec alchemist \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,10 @@
 aiobotocore[awscli]==1.1.2
 boto3==1.14.44
 botocore==1.17.44
-fc
+# Pinned for production DEA run
+fc==1.3.2
+wofs==1.5.6
 odc-aws
 odc-index
-wofs
 odc-apps-cloud
 odc-apps-dc-tools


### PR DESCRIPTION
This enables us to not accidentally change the algorithm processing our data.