### PR TITLE
A fix and a feaure

### DIFF
--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -231,7 +231,9 @@ def redrive_to_queue(queue, to_queue, limit, dryrun):
                 _LOG.error(f"Unable to send message {message} to queue")
         _LOG.info(f"Completed sending {count} messages to the queue")
     else:
-        _LOG.warning(f"DRYRUN enabled, would have pushed approx {count_messages} messages to the queue")
+        _LOG.warning(
+            f"DRYRUN enabled, would have pushed approx {count_messages} messages to the queue"
+        )
 
 
 if __name__ == "__main__":

--- a/datacube_alchemist/worker.py
+++ b/datacube_alchemist/worker.py
@@ -257,16 +257,16 @@ class Alchemist:
                 on sub_d.id = sub_s.dataset_ref
                 join agdc.dataset_type as sub_t
                 on sub_d.dataset_type_ref = sub_t.id
-                where sub_t.name = %{output_product}s
+                where sub_t.name = '{output_product}'
             ) as s
             on d.id = s.source_dataset_ref
-            where t.name in %{input_products}s
+            where t.name in ({input_products})
             and s.dataset_ref is null
             and d.archived is null
         """
 
         # Most of this guff is just to get a destination product name...
-        input_products = [p.name for p in self.input_products]
+        input_products = ", ".join(f"'{p.name}'" for p in self.input_products)
         output_product = ""
 
         dataset = self.dc.find_datasets(product=self.input_products[0].name, limit=1)
@@ -296,9 +296,7 @@ class Alchemist:
         conn = psycopg2.connect(str(self.dc.index.url))
         cur = conn.cursor()
 
-        cur.execute(
-            query, dict(input_products=input_products, output_product=output_product)
-        )
+        cur.execute(query.format(input_products=input_products, output_product=output_product))
         results = cur.fetchall()
         _LOG.info(
             (

--- a/datacube_alchemist/worker.py
+++ b/datacube_alchemist/worker.py
@@ -296,7 +296,9 @@ class Alchemist:
         conn = psycopg2.connect(str(self.dc.index.url))
         cur = conn.cursor()
 
-        cur.execute(query.format(input_products=input_products, output_product=output_product))
+        cur.execute(
+            query.format(input_products=input_products, output_product=output_product)
+        )
         results = cur.fetchall()
         _LOG.info(
             (

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,7 @@
 import io
 from setuptools import setup, find_packages
 
-dev_requirements = [
-    "black",
-    "pytest",
-    "pytest-cov"
-]
+dev_requirements = ["black", "pytest", "pytest-cov"]
 
 setup(
     name="datacube-alchemist",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,22 @@ def run_alchemist():
     A helpful fixture for running a a click CLI from within pytest
     """
 
-    def _run_cli(*opts, catch_exceptions=False, expect_success=True, cli_method=datacube_alchemist.cli.cli):
+    def _run_cli(
+        *opts,
+        catch_exceptions=False,
+        expect_success=True,
+        cli_method=datacube_alchemist.cli.cli
+    ):
         exe_opts = []
         exe_opts.extend(opts)
 
         runner = CliRunner()
         result = runner.invoke(cli_method, exe_opts, catch_exceptions=catch_exceptions)
         if expect_success:
-            assert 0 == result.exit_code, "Error for %r. output: %r" % (opts, result.output)
+            assert 0 == result.exit_code, "Error for %r. output: %r" % (
+                opts,
+                result.output,
+            )
         return result
 
     return _run_cli
@@ -26,7 +34,7 @@ def run_alchemist():
 
 @pytest.fixture
 def config_file():
-    return Path(__file__).absolute().parent.parent / 'examples/c3_config_wo.yaml'
+    return Path(__file__).absolute().parent.parent / "examples/c3_config_wo.yaml"
 
 
 @pytest.fixture

--- a/tests/test_datacube_alchemist.py
+++ b/tests/test_datacube_alchemist.py
@@ -4,13 +4,13 @@ from datacube_alchemist.worker import Alchemist
 def test_alchemist_local_config(config_file):
     alchemist = Alchemist(config_file=config_file)
 
-    assert alchemist.transform_name == 'wofs.virtualproduct.WOfSClassifier'
+    assert alchemist.transform_name == "wofs.virtualproduct.WOfSClassifier"
 
 
 def test_alchemist_remote_config(remote_config_file):
     alchemist = Alchemist(config_file=remote_config_file)
 
-    assert alchemist.transform_name == 'wofs.virtualproduct.WOfSClassifier'
+    assert alchemist.transform_name == "wofs.virtualproduct.WOfSClassifier"
 
 
 def test_help_message(run_alchemist):


### PR DESCRIPTION
Add a `--dryrun` flag to the redrive-to-queue function

Also fixed up the query for filling missing datasets. Nobody is going to SQL inject using product names.