### PR TITLE
Added --version flag and _version file writing, closes #67

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ venv.bak/
 .vscode/
 datacube-index/
 output
+
+# Let setuptools_scm manage the _version.py file
+datacube_alchemist/_version.py

--- a/datacube_alchemist/__init__.py
+++ b/datacube_alchemist/__init__.py
@@ -1,7 +1,4 @@
-from pkg_resources import get_distribution, DistributionNotFound
-
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = "package-not-installed"
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "Unknown/Not Installed"

--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -69,10 +69,14 @@ def cli_with_envvar_handling():
 
 @click.group(context_settings=dict(max_content_width=120),
              invoke_without_command=True)
-def cli():
+@click.option('--version', is_flag=True, default=False)
+def cli(version):
     """
     Transform Datasets from the Open Data Cube into a new type of Dataset
     """
+    if version:
+        click.echo(__version__)
+
     # Set up opinionated logging
     _configure_logger()
 
@@ -236,11 +240,6 @@ def redrive_to_queue(queue, to_queue, limit, dryrun):
         _LOG.warning(
             f"DRYRUN enabled, would have pushed approx {count_messages} messages to the queue"
         )
-
-
-@cli.command('--version')
-def echo_version():
-    click.echo(__version__)
 
 
 if __name__ == "__main__":

--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -67,9 +67,8 @@ def cli_with_envvar_handling():
     cli(auto_envvar_prefix="ALCHEMIST")
 
 
-@click.group(context_settings=dict(max_content_width=120),
-             invoke_without_command=True)
-@click.option('--version', is_flag=True, default=False)
+@click.group(context_settings=dict(max_content_width=120), invoke_without_command=True)
+@click.option("--version", is_flag=True, default=False)
 def cli(version):
     """
     Transform Datasets from the Open Data Cube into a new type of Dataset

--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -6,6 +6,7 @@ import click
 from datacube.ui import click as ui
 
 from datacube_alchemist._utils import _configure_logger
+from datacube_alchemist._version import version as __version__
 import structlog
 
 from odc.aws.queue import get_queue
@@ -234,6 +235,11 @@ def redrive_to_queue(queue, to_queue, limit, dryrun):
         _LOG.warning(
             f"DRYRUN enabled, would have pushed approx {count_messages} messages to the queue"
         )
+
+
+@cli.command('--version')
+def echo_version():
+    click.echo(__version__)
 
 
 if __name__ == "__main__":

--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -6,7 +6,7 @@ import click
 from datacube.ui import click as ui
 
 from datacube_alchemist._utils import _configure_logger
-from datacube_alchemist._version import version as __version__
+from datacube_alchemist import __version__
 import structlog
 
 from odc.aws.queue import get_queue

--- a/datacube_alchemist/cli.py
+++ b/datacube_alchemist/cli.py
@@ -67,7 +67,8 @@ def cli_with_envvar_handling():
     cli(auto_envvar_prefix="ALCHEMIST")
 
 
-@click.group(context_settings=dict(max_content_width=120))
+@click.group(context_settings=dict(max_content_width=120),
+             invoke_without_command=True)
 def cli():
     """
     Transform Datasets from the Open Data Cube into a new type of Dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
 [tool.setuptools_scm]
-write_to = "datacube_alchemist/_version.py
+write_to = "datacube_alchemist/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.setuptools_scm]
+write_to = "datacube_alchemist/_version.py


### PR DESCRIPTION
This PR adds a --version flag to datacube-alchemist:

```
jovyan@jupyter-alger:~/dea-datacube-alchemist$ datacube-alchemist --version
0.3.8a0
```

It also sets `setuptools_scm` to write a `_version.py` file which will hopefully fix #67.

@alexgleith 