### PR TITLE
Added gqa_eo support, resolving #73

### DIFF
--- a/datacube_alchemist/_utils.py
+++ b/datacube_alchemist/_utils.py
@@ -136,8 +136,9 @@ def _munge_dataset_to_eo3(ds: Dataset) -> DatasetDoc:
     """
     Convert to the DatasetDoc format that eodatasets expects.
     """
-    if ds.metadata_type.name in {"eo_plus", "eo_s2_nrt"}:
+    if ds.metadata_type.name in {"eo_plus", "eo_s2_nrt", "gqa_eo"}:
         # Handle S2 NRT metadata identically to eo_plus files.
+        # gqa_eo is the S2 ARD with extra quality check fields.
         return _convert_eo_plus(ds)
 
     if ds.metadata_type.name == "eo":


### PR DESCRIPTION
Added `gqa_eo` alongside `eo_plus` and `eo_s2_nrt`. Long-term, it'd be good to just try and grab fields from the metadata and fall through if they aren't there, but this fixes the issue for now.