### PR TITLE
Add URL for transforms

### DIFF
--- a/datacube_alchemist/settings.py
+++ b/datacube_alchemist/settings.py
@@ -36,6 +36,7 @@ class OutputSettings:
 class Specification:
     measurements: Sequence[str]
     transform: str
+    transform_url: Optional[str] = ""
     product: Optional[str] = None
     products: Optional[Sequence[str]] = None
     measurement_renames: Optional[Mapping[str, str]] = None

--- a/datacube_alchemist/worker.py
+++ b/datacube_alchemist/worker.py
@@ -183,7 +183,7 @@ class Alchemist:
         return {
             "version": version,
             "version_major_minor": version_major_minor,
-            "url": "",
+            "url": self.config.specification.transform_url,
         }
 
     def _datasets_to_queue(self, queue, datasets):

--- a/examples/c3_config_fc.yaml
+++ b/examples/c3_config_fc.yaml
@@ -12,6 +12,7 @@ specification:
     nbart_swir_2: swir2
 
   transform: fc.virtualproduct.FractionalCover
+  transform_url: 'https://github.com/GeoscienceAustralia/fc/'
   override_product_family: ard
   basis: nbart_green
 

--- a/examples/c3_config_wo.yaml
+++ b/examples/c3_config_wo.yaml
@@ -7,6 +7,7 @@ specification:
   measurement_renames:
     oa_fmask: fmask
   transform: wofs.virtualproduct.WOfSClassifier
+  transform_url: 'https://github.com/GeoscienceAustralia/wofs/'
   override_product_family: ard
   basis: nbart_green
 


### PR DESCRIPTION
As reported by @simonaoliver, we're not including a URL for the transform we're using.

So, added the URL to the proc-info and config.