### PR TITLE
Only pin the cattr depedency on older Python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     datacube
     eodatasets3>=0.22.0
     attrs>=18.1
-    cattrs==1.0.0
+    cattrs==1.0.0;python_version<'3.7'
     structlog
     boto3
     dask


### PR DESCRIPTION
The cattrs dependency was hard pinned to version 1.0.0 in commit 02a353e6d55270ca4455d1a46da9749c55d73699

The commit message doesn't say why it was done, but I believe this was because 1.0.0 was the [last version](https://github.com/Tinche/cattrs/blob/master/HISTORY.rst#110-2020-10-29) of cattrs that worked with Python 3.6. I had the same problem on another repo.

But cattrs 1.0.0 doesn't work on Python 3.9+ due to importing `_Typing`.

Hard-pinning also makes it hard to install Alchemist alongside other software that uses newer cattrs.

So I think we should only pin cattrs's setup.py on the affected Python versions.