### PR TITLE
Remove Slack notification from CVE scan - Slack is no longer monitored

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,15 +40,3 @@ jobs:
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH"
-
-      - name: Notify Slack for Failures
-        uses: rtCamp/action-slack-notify@v2.2.0
-        if: failure()
-        env:
-          SLACK_CHANNEL: ga-wms-ops
-          SLACK_ICON: "https://github.com/docker.png?size=48"
-          SLACK_COLOR: "#482de1"
-          SLACK_MESSAGE: ""
-          SLACK_TITLE: CVE Scan alert
-          SLACK_USERNAME: Alchemist Scanner
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
No point posting notifications that nobody reads.