### PR TITLE
CI: pass token to codecov

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
 
     - name: Integration tests


### PR DESCRIPTION
This is how things are configured
in datacube-core and datacube-ows.