### PR TITLE
Sort imports with Ruff

### DIFF
--- a/datacube_alchemist/_utils.py
+++ b/datacube_alchemist/_utils.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Dict
 
 import boto3
@@ -15,7 +15,6 @@ from eodatasets3.verify import PackageChecksum
 from toolz.dicttoolz import get_in
 
 from datacube_alchemist.settings import AlchemistTask
-
 
 # Regex for extracting region codes from tile IDs.
 RE_TILE_REGION_CODE = re.compile(r".*A\d{6}_T(\w{5})_N\d{2}\.\d{2}")

--- a/datacube_alchemist/settings.py
+++ b/datacube_alchemist/settings.py
@@ -1,10 +1,9 @@
-from typing import Optional, Mapping, Sequence, Any, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import attr
 import cattr
-from rasterio.enums import Resampling
-
 from datacube.model import Dataset
+from rasterio.enums import Resampling
 
 
 def _convert_union_mapping(obj, typ):

--- a/datacube_alchemist/transforms.py
+++ b/datacube_alchemist/transforms.py
@@ -9,9 +9,9 @@ from datacube import Datacube
 from datacube.utils.rio import configure_s3_access
 from datacube.virtual import Measurement, Transformation
 from nrtmodels import (
-    UnsupervisedBurnscarDetect2,
     # UnsupervisedBurnscarDetect1,
     SupervisedBurnscarDetect1,
+    UnsupervisedBurnscarDetect2,
 )
 from odc.algo import int_geomedian
 

--- a/datacube_alchemist/worker.py
+++ b/datacube_alchemist/worker.py
@@ -9,17 +9,22 @@ from pathlib import Path
 from typing import Iterable, Mapping, Type, Union
 
 import cattr
+import datacube
 import fsspec
 import numpy as np
 import psycopg2
 import structlog
 import yaml
-
-import datacube
 from datacube.model import Dataset
 from datacube.testutils.io import native_geobox, native_load
 from datacube.utils.aws import configure_s3_access
 from datacube.virtual import Transformation
+from eodatasets3.assemble import DatasetAssembler
+from odc.apps.dc_tools._docs import odc_uuid
+from odc.apps.dc_tools._stac import stac_transform
+from odc.aws import s3_url_parse
+from odc.aws.queue import get_messages, get_queue
+
 from datacube_alchemist import __version__
 from datacube_alchemist._utils import (
     _munge_dataset_to_eo3,
@@ -28,11 +33,6 @@ from datacube_alchemist._utils import (
     _write_thumbnail,
 )
 from datacube_alchemist.settings import AlchemistSettings, AlchemistTask
-from eodatasets3.assemble import DatasetAssembler
-from odc.apps.dc_tools._docs import odc_uuid
-from odc.apps.dc_tools._stac import stac_transform
-from odc.aws import s3_url_parse
-from odc.aws.queue import get_messages, get_queue
 
 _LOG = structlog.get_logger()
 cattr.register_structure_hook(np.dtype, np.dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
+[tool.ruff.lint]
+select = [
+    "I",  # isort
+]
+
 [tool.setuptools_scm]
 write_to = "datacube_alchemist/_version.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import json
 from pathlib import Path
 
-import datacube_alchemist.cli
 import pytest
 from click.testing import CliRunner
+
+import datacube_alchemist.cli
 
 
 @pytest.fixture

--- a/tests/test_datacube_alchemist.py
+++ b/tests/test_datacube_alchemist.py
@@ -1,8 +1,8 @@
-from datacube_alchemist.worker import Alchemist
-from moto import mock_sqs, mock_sns
 import boto3
+from moto import mock_sns, mock_sqs
 
 from datacube_alchemist._utils import _stac_to_sns
+from datacube_alchemist.worker import Alchemist
 
 TEST_QUEUE_NAME = "alchemist-test-queue"
 


### PR DESCRIPTION
Sort imports and enable the check
in precommit. This aligns behavior
with datacube-core, explorer, and
OWS.