### PR TITLE
CI: run with fewer permissions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,12 @@ on:
   release:
     types: [published]
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   publish_pypi:
     if: github.repository == 'opendatacube/datacube-alchemist'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:
@@ -15,6 +17,9 @@ jobs:
     if: github.repository == 'opendatacube/datacube-alchemist'
 
     runs-on: ubuntu-latest
+    # Permit authenticating to PyPI
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,6 +7,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/datacube-alchemist
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cve-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,6 +7,8 @@ on:
 env:
   IMAGE_NAME: opendatacube/datacube-alchemist
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -35,6 +35,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/datacube-alchemist
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -35,6 +35,8 @@ on:
 env:
   IMAGE_NAME: opendatacube/datacube-alchemist
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:


### PR DESCRIPTION
Set the top level permissions
to the empty set so CI jobs
don't run with excessive
permissions.

Also put in the standard boilerplate
for cancelling running jobs when
the PR updates.