### PR TITLE
CI: shorten job timeout

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   publish_pypi:
     if: github.repository == 'opendatacube/datacube-alchemist'
-
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     # Permit authenticating to PyPI
     permissions:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   cve-scanner:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   test:
+    timeout-minutes: 35
     runs-on: ubuntu-latest
 
     steps:
@@ -83,7 +84,7 @@ jobs:
   push:
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     needs: test
-
+    timeout-minutes: 45
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This prevents us from having to
wait for 6 hours if someone
hangs the CI machines.